### PR TITLE
Clarify "more efficient to count down" advice

### DIFF
--- a/chapter03.md
+++ b/chapter03.md
@@ -30,7 +30,7 @@ This is a simple loop that runs for 638 iterations, counting down from 638 to 0.
          JMP INNER     # Iterate the loop.
         DONE:
 
-Since TIS-100's conditional jump instructions are based on comparing `ACC` to zero, on every iteration we have to subtract 638 from the counter, compare the result to 0, then add 638 back again. This takes up 2 extra lines of code and 2 extra cycles per loop iteration. (Note: this loop runs for 639 iterations instead of 638. To understand why, try mentally walking through both loops using 2 for the number of iterations.)
+Since TIS-100's conditional jump instructions are based on comparing `ACC` to zero, on every iteration we have to subtract 638 from the counter, compare the result to 0, then add 638 back again. This takes up 2 extra lines of code and 2 extra cycles per loop iteration. (Note: having the exit command `JEZ` in the middle of the loop also makes it easier to introduce [off-by-one errors](https://en.wikipedia.org/wiki/Off-by-one_error); any parts of the loop above the `JEZ` will execute 639 times, while the parts below will execute 638 times. To understand why, try mentally walking through both loops but counting to 2 instead of 638.)
 
 Back to the program:
 

--- a/chapter03.md
+++ b/chapter03.md
@@ -21,16 +21,16 @@ Mostly the same as the optimized version, but let's take a look at node 0. It sp
         INNER: SUB 1    #5
          JGZ INNER      #6
 
-This is a simple loop that runs for 638 iterations, counting down from 638 to 0. It's almost always more efficient to count down than up in TIS-100; here's what the same loop would look like, but counting up from 0 to 638:
+This is a simple loop that runs for 638 iterations, counting down from 638 to 0. It's almost always more efficient to count from _N_ to 0 than from 0 to _N_ in TIS-100; here's what the same loop would look like, but counting from 0 to 638:
 
-         MOV 0 ACC
-        INNER: SUB 638
-         JEZ DONE
-         ADD 639
-         JMP INNER
+         MOV 0 ACC     # Initialize counter to 0.
+        INNER: SUB 638 # Check if the counter is at 638...
+         JEZ DONE      # ...using subtraction and <0 comparison.
+         ADD 639       # Reverse the subtraction and add 1.
+         JMP INNER     # Iterate the loop.
         DONE:
 
-Since our only conditional jumps are based on comparing `ACC` to zero, we have to check `ACC` _minus 638_ on each iteration, then add back 638+1 before going on to the next iteration. This takes up 2 extra lines of code and 2 extra cycles per loop iteration. (Note: this loop runs for 639 iterations instead of 638. To understand why, try mentally walking through both loops using 2 for the number of iterations.)
+Since TIS-100's conditional jump instructions are based on comparing `ACC` to zero, on every iteration we have to subtract 638 from the counter, compare the result to 0, then add 638 back again. This takes up 2 extra lines of code and 2 extra cycles per loop iteration. (Note: this loop runs for 639 iterations instead of 638. To understand why, try mentally walking through both loops using 2 for the number of iterations.)
 
 Back to the program:
 


### PR DESCRIPTION
The advice that "It's almost always more efficient to count down" is technically correct, but easy to misinterpret. It's correct in the sense that you almost always encounter situations where you have a positive number N and you need to loop N times, so it's more efficient to count down from N to 0, rather than 0 to N.

But when I first read this passage (and until I carefully re-read it, and the sample code), I misinterpreted it as incorrectly saying that counting from -638 to 0 was less efficient than counting from +638 to 0. And based on that I misread the sample code as a poorly implemented -638 to 0 loop.

This change aims to clarify the section to avoid others making the same misinterpretation.